### PR TITLE
Expand test output to result, reason, analysis

### DIFF
--- a/tests/sync/G.8272/time-error-in-locked-mode/PRTC-A/DPLL-to-PHC/testimpl.py
+++ b/tests/sync/G.8272/time-error-in-locked-mode/PRTC-A/DPLL-to-PHC/testimpl.py
@@ -12,6 +12,7 @@ import json
 from os.path import join as joinpath
 from os.path import dirname
 
+from vse_sync_pp.common import JsonEncoder
 from vse_sync_pp.parsers.ts2phc import TimeErrorParser
 from vse_sync_pp.analyzers.ts2phc import TimeErrorAnalyzer
 from vse_sync_pp.analyzers.analyzer import Config
@@ -23,21 +24,25 @@ def refimpl(filename, encoding='utf-8'):
 
     sync/G.8272/time-error-in-locked-mode/PRTC-A/DPLL-to-PHC
 
-    Return a boolean test result from the analysis of logs in `filename`.
+    Return a dict with test result, reason, analysis of logs in `filename`.
     """
     parser = TimeErrorParser()
     analyzer = TimeErrorAnalyzer(Config.from_yaml(CONFIG))
     with open(filename, encoding=encoding) as fid:
         analyzer.collect(*parser.parse(fid))
-    return analyzer.result
+    return {
+        'result': analyzer.result,
+        'reason': analyzer.reason,
+        'analysis': analyzer.analysis,
+    }
 
 def main():
-    """Run this test and print test result as JSON boolean to stdout"""
+    """Run this test and print test output as JSON to stdout"""
     aparser = ArgumentParser(description=main.__doc__)
     aparser.add_argument('input', help="log file to analyze")
     args = aparser.parse_args()
-    result = refimpl(args.input)
-    print(json.dumps(result))
+    output = refimpl(args.input)
+    print(json.dumps(output, cls=JsonEncoder))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Reflecting improvements in [vse-sync-pp](https://github.com/redhat-partner-solutions/vse-sync-pp/commit/ef97a17dbf7e52d4483d5ed1a3a958084680c905)

```
[dspence@fedora DPLL-to-PHC]$ env PYTHONPATH=~/vse-sync-pp.git/src/ ./testimpl.py examples/ts2phc-accept.log 
{"result": true, "reason": null, "analysis": {"duration": 6665.0, "terror": {"units": "ns", "min": -1, "max": 1, "range": 2, "mean": 0.0, "stddev": 0.227, "variance": 0.051}}}
[dspence@fedora DPLL-to-PHC]$ env PYTHONPATH=~/vse-sync-pp.git/src/ ./testimpl.py examples/ts2phc-reject.log 
{"result": false, "reason": "unacceptable time error", "analysis": {"duration": 4980.0, "terror": {"units": "ns", "min": -199928186, "max": 1000000000, "range": 1199928186, "mean": 870883.394, "stddev": 30958230.595, "variance": 958412041594393.4}}}
```