### PR TITLE
normalize timestamps

### DIFF
--- a/tests/sync/G.8272/time-error-in-locked-mode/1PPS-to-DPLL/plot.py
+++ b/tests/sync/G.8272/time-error-in-locked-mode/1PPS-to-DPLL/plot.py
@@ -28,7 +28,7 @@ def main():
     parser = TimeErrorParser()
     plotter = Plotter(parser.y_name, "Time Error (unfiltered)")
     with open_input(args.input) as fid:
-            for parsed in parser.canonical(fid):
+            for parsed in parser.canonical(fid, relative=True):
                 plotter.append(parsed)
     plotter.plot(args.output)
 

--- a/tests/sync/G.8272/time-error-in-locked-mode/Constellation-to-GNSS-receiver/plot.py
+++ b/tests/sync/G.8272/time-error-in-locked-mode/Constellation-to-GNSS-receiver/plot.py
@@ -28,7 +28,7 @@ def main():
     parser = TimeErrorParser()
     plotter = Plotter(parser.y_name, "Time Error (unfiltered)")
     with open_input(args.input) as fid:
-            for parsed in parser.canonical(fid):
+            for parsed in parser.canonical(fid, relative=True):
                 plotter.append(parsed)
     plotter.plot(args.output)
 

--- a/tests/sync/G.8272/time-error-in-locked-mode/DPLL-to-PHC/plot.py
+++ b/tests/sync/G.8272/time-error-in-locked-mode/DPLL-to-PHC/plot.py
@@ -28,7 +28,7 @@ def main():
     parser = TimeErrorParser()
     plotter = Plotter(parser.y_name, "Time Error (unfiltered)")
     with open_input(args.input) as fid:
-            for parsed in parser.parse(fid):
+            for parsed in parser.parse(fid, relative=True):
                 plotter.append(parsed)
     plotter.plot(args.output)
 

--- a/tests/sync/G.8272/time-error-in-locked-mode/PHC-to-SYS/plot.py
+++ b/tests/sync/G.8272/time-error-in-locked-mode/PHC-to-SYS/plot.py
@@ -28,7 +28,7 @@ def main():
     parser = TimeErrorParser()
     plotter = Plotter(parser.y_name, "Time Error (unfiltered)")
     with open_input(args.input) as fid:
-            for parsed in parser.parse(fid):
+            for parsed in parser.parse(fid, relative=True):
                 plotter.append(parsed)
     plotter.plot(args.output)
 


### PR DESCRIPTION
This PR depends on [34](https://github.com/redhat-partner-solutions/vse-sync-pp/pull/34). This PR uses capability to use absolute timetamps or relative timestamps for plotting for normalizing the x-axis of the graphs inthe test report.