### PR TITLE
Add nodeName as a new parameter to support MNO cluster testing

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,6 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
-
+#node name should be passed in when testing an MNO cluster defaulting to SNO usecase of empty.
+ARG NODENAME=""
 RUN microdnf install -y git golang python3 python3-pip tar python3-yaml jq ruby
 RUN pip3 install pandas junitparser matplotlib allantools
 RUN gem install asciidoctor-pdf:2.3.9 asciidoctor-diagram:2.2.14 rouge:3.30.0
@@ -20,4 +21,4 @@ WORKDIR ${VSE_DIR}/vse-sync-collection-tools
 RUN go mod vendor
 
 WORKDIR ${VSE_DIR}
-CMD ["./vse-sync-test/cmd/e2e.sh", "-d", "2000s", "/usr/vse/kubeconfig"]
+CMD ["./vse-sync-test/cmd/e2e.sh", "-d", "2000s","-n","$NODENAME" ,"/usr/vse/kubeconfig"]

--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 #node name should be passed in when testing an MNO cluster defaulting to SNO usecase of empty.
-ARG NODENAME=""
+ENV PTPNODENAME=""
 RUN microdnf install -y git golang python3 python3-pip tar python3-yaml jq ruby
 RUN pip3 install pandas junitparser matplotlib allantools
 RUN gem install asciidoctor-pdf:2.3.9 asciidoctor-diagram:2.2.14 rouge:3.30.0
@@ -21,4 +21,4 @@ WORKDIR ${VSE_DIR}/vse-sync-collection-tools
 RUN go mod vendor
 
 WORKDIR ${VSE_DIR}
-CMD ["./vse-sync-test/cmd/e2e.sh", "-d", "2000s","-n","$NODENAME" ,"/usr/vse/kubeconfig"]
+CMD ["./vse-sync-test/cmd/e2e.sh", "-d", "2000s","-n","$PTPNODENAME" ,"/usr/vse/kubeconfig"]

--- a/README.adoc
+++ b/README.adoc
@@ -99,6 +99,22 @@ podman run \
   -v /home/redhat/tmp/data:/usr/vse/data:Z \
   quay.io/redhat-partner-solutions/vse-sync-test:latest ./vse-sync-test/cmd/e2e.sh
 ----
+== MNO Support
+
+If you are looking to run the tests on a Grandmaster interface on an Multi Node Cluster we
+need to pass in an additional value to the container. We need to set the ptpNodeName,
+which is the node that has the NIC connected to the GNSS signal. The nodeName is passed as
+an environment variable.
+
+For example:
+[source,shell]
+----
+podman run \
+  -e $PTPNODENAME=<nodeName>
+  -v ~/kubeconfig:/usr/vse/kubeconfig:Z \
+  -v /home/redhat/tmp/data:/usr/vse/data:Z \
+  quay.io/redhat-partner-solutions/vse-sync-test:latest
+----
 
 == Development Setup
 

--- a/README.adoc
+++ b/README.adoc
@@ -110,7 +110,7 @@ For example:
 [source,shell]
 ----
 podman run \
-  -e $PTPNODENAME=<nodeName>
+  -e PTPNODENAME=<nodeName>
   -v ~/kubeconfig:/usr/vse/kubeconfig:Z \
   -v /home/redhat/tmp/data:/usr/vse/data:Z \
   quay.io/redhat-partner-solutions/vse-sync-test:latest


### PR DESCRIPTION
added changes to include a new parameter nodeName to pass in the the node to test in an MNO cluster.

   * updated e2e.sh to add validations and pass in the nodeName to the verify env and collect scripts.
   * updated Containerfile to add in nodeName as an argument set to emptyString by default (SNO case)