### PR TITLE
Clean up ptp node name handling

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -21,4 +21,4 @@ WORKDIR ${VSE_DIR}/vse-sync-collection-tools
 RUN go mod vendor
 
 WORKDIR ${VSE_DIR}
-CMD ["./vse-sync-test/cmd/e2e.sh", "-d", "2000s","-n","$PTPNODENAME" ,"/usr/vse/kubeconfig"]
+CMD ["./vse-sync-test/cmd/e2e.sh", "-d", "2000s", "/usr/vse/kubeconfig"]

--- a/cmd/e2e.sh
+++ b/cmd/e2e.sh
@@ -43,8 +43,7 @@ FULLJUNIT="$OUTPUTDIR/sync_test_report.xml"
 # defaults
 DURATION=2000s
 NAMESPACE=openshift-ptp
-NODE_NAME=""
-GNSS_NAME=
+NODE_NAME="$PTPNODENAME"
 DIFF_LOG=0
 
 usage() {
@@ -84,6 +83,10 @@ done
 shift $((OPTIND - 1))
 
 LOCAL_KUBECONFIG="$1"
+
+if [ ! -z $NODE_NAME ]; then
+    echo "Using node name ${NODE_NAME}"
+fi
 
 detect_configured_cards() {
     pushd "$COLLECTORPATH" >/dev/null 2>&1


### PR DESCRIPTION
CMD does not expand bash variables so $PTPNODENAME is removed from the CMD list

Also adds echo to tell user the if $NODE_NAME (defaults to $PTPNODENAME is not empty