### PR TITLE
Add deprecation notice: redirect to vse-sync-tests monorepo

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,3 +1,12 @@
+[IMPORTANT]
+====
+This repository has been consolidated into the
+https://github.com/openshift-kni/vse-sync-tests[vse-sync-tests] monorepo.
+All future development will happen there.
+Please open issues and pull requests against
+https://github.com/openshift-kni/vse-sync-tests[openshift-kni/vse-sync-tests].
+====
+
 = Synchronization tests
 
 This repository contains tests for Synchronization use cases.


### PR DESCRIPTION
## Summary
- Adds a prominent deprecation notice at the top of the README
- Directs contributors to the new monorepo at [openshift-kni/vse-sync-tests](https://github.com/openshift-kni/vse-sync-tests)
- All existing README content is preserved below the notice


Made with [Cursor](https://cursor.com)